### PR TITLE
feat: Optimize analysis page loading by direct ID lookup

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -369,6 +369,26 @@ const extractBrandName = (siteName: string, siteUrl: string): string => {
   }
 };
 
+// Get analysis by ID from IndexedDB
+export const getAnalysisById = async (id: number): Promise<PrivacyAnalysis | undefined> => {
+  return handleDBOperation(async (db) => {
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readonly');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(id);
+
+      request.onsuccess = () => {
+        resolve(request.result); // Resolves with the object or undefined if not found
+      };
+
+      request.onerror = () => {
+        console.error('Error fetching analysis by ID:', request.error);
+        reject(request.error);
+      };
+    });
+  });
+};
+
 // Initialize database and return support status
 export const initializeDatabase = async (): Promise<boolean> => {
   try {


### PR DESCRIPTION
Introduces a new `getAnalysisById` function in `src/lib/db.ts` to allow fetching a single privacy analysis directly from IndexedDB using its numerical ID.

The `AnalysisPage.tsx` component has been updated to utilize this new function. Previously, it would fetch all unique analyses and then perform a client-side search. This change significantly improves performance when loading specific analysis detail pages, especially when a large number of analyses are stored in the browser.

The page now:
- Parses the ID from the URL.
- Calls `getAnalysisById` for direct data retrieval.
- Continues to verify the `brandName` from the URL against the fetched record to ensure URL consistency, redirecting to the homepage if there's a mismatch or if the ID is not found.