### PR TITLE
Fix: Improve URL parsing and error handling for analysis reports

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -12,37 +12,40 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch, isLoading }) => {
   const [error, setError] = useState('');
   
   const validateUrl = (input: string): boolean => {
-    // Basic URL validation
-    if (!input.trim()) {
-      setError('Please enter a URL');
+    const trimmedInput = input.trim();
+
+    if (!trimmedInput) {
+      setError('Please enter a URL or domain name.');
+      return false;
+    }
+
+    // Check for a dot, basic check for domain/URL structure
+    if (!trimmedInput.includes('.')) {
+      setError('Invalid format. Please enter a valid domain (e.g., example.com) or a full URL.');
+      return false;
+    }
+
+    // If it looks like a full URL path, it should have a scheme
+    if (trimmedInput.includes('/') && !trimmedInput.match(/^https?:\/\//i)) {
+      setError('Full URLs should start with http:// or https://. For domains like example.com, we will try https automatically.');
       return false;
     }
     
-    // If it's just a domain name, that's fine now - we'll find the privacy policy
-    if (!input.includes('/') && !input.includes(' ')) {
-      setError('');
-      return true;
+    // Add any other simple, universal URL validation if desired (e.g. no spaces)
+    if (trimmedInput.includes(' ')) {
+        setError('URL cannot contain spaces.');
+        return false;
     }
-    
-    // Check if it looks like a privacy policy URL
-    const lowerInput = input.toLowerCase();
-    const privacyKeywords = ['privacy', 'policy', 'data', 'terms'];
-    const containsPrivacyKeyword = privacyKeywords.some(keyword => lowerInput.includes(keyword));
-    
-    if (!containsPrivacyKeyword) {
-      setError('This doesn\'t look like a privacy policy URL. We\'ll try to find the privacy policy for this domain.');
-      // Still return true since we'll try to find the privacy policy
-      return true;
-    }
-    
+
     setError('');
     return true;
   };
   
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (validateUrl(url)) {
-      onSearch(url);
+    const trimmedUrl = url.trim(); // Trim the URL
+    if (validateUrl(trimmedUrl)) { // Validate the trimmed URL
+      onSearch(trimmedUrl); // Pass the trimmed URL to onSearch
     }
   };
   

--- a/src/utils/analyzer.ts
+++ b/src/utils/analyzer.ts
@@ -312,12 +312,16 @@ export const findPrivacyPolicyUrl = async (
       }
     }
     
-    // If all else fails, just return the domain (we'll try to find the policy on the main page)
-    console.log('No privacy policy found, using domain:', domain);
-    return domain; // Return the original domain as fallback
+    // If all else fails, throw an error
+    console.log('No privacy policy found for domain:', domain);
+    throw new Error('Could not automatically locate the privacy policy URL for this domain. Please try providing a direct link to the privacy policy.');
   } catch (error) {
     console.error('Error finding privacy policy URL:', error);
-    return domain; // Return the original domain as fallback
+    if (error instanceof Error) {
+      throw error; // Re-throw the original error
+    }
+    // If it's not an Error instance, wrap it or throw a generic one
+    throw new Error('An unknown error occurred while trying to find the privacy policy URL.');
   }
 };
 


### PR DESCRIPTION
This commit addresses an issue where URL parsing failures or content extraction problems would lead to analysis reports not being shown, without clear feedback to you.

Key changes include:

1.  `SearchBar.tsx`:
    - Implemented stricter URL validation in the search bar.
    - Provides clearer, more specific error messages for invalid URL formats (e.g., missing scheme for full URLs, no domain-like structure).

2.  `utils/analyzer.ts`:
    - Modified `findPrivacyPolicyUrl` to throw a specific error if it cannot automatically locate a privacy policy URL, instead of defaulting to the base domain. This prevents attempts to analyze non-policy pages.
    - Ensured that catch blocks in `findPrivacyPolicyUrl` correctly propagate any encountered errors.

3.  `pages/AnalysisPage.tsx`:
    - Introduced an `analysisError` state to store and display error messages directly on the page.
    - Updated `handleRefresh` and `loadAnalysis` to catch errors from the analysis pipeline and set the `analysisError` state.
    - The UI now shows a user-friendly message if an analysis cannot be loaded or refreshed, indicating the nature of the problem instead of a blank/redirected page.

These changes improve the robustness of the privacy policy analysis feature and provide better feedback to you when issues occur during URL processing or content fetching.