### PR TITLE
fix: Add missing closing div tag in progress UI

### DIFF
--- a/src/components/PrivacyAnalyzer.tsx
+++ b/src/components/PrivacyAnalyzer.tsx
@@ -343,6 +343,7 @@ export default function PrivacyAnalyzer() {
                     />
                   </div>
                 </div>
+              </div>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
- Fixed JSX parsing error on Vercel build
- Added missing closing </div> for space-y-4 container
- Build now passes successfully that my contribution is made under the terms of the project's license.**
