### PR TITLE
feat: Add Google Analytics tracking with hardcoded Measurement ID

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono, Poppins } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 
 // Force rebuild: CSS cache invalidation
 
@@ -106,6 +107,7 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable} ${poppins.variable} font-sans antialiased min-h-screen bg-white`}>
+        <GoogleAnalytics measurementId="G-Y6PVP4X0SN" />
         <Header />
         <main>{children}</main>
         <Footer />

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Script from 'next/script';
+
+interface GoogleAnalyticsProps {
+  measurementId: string;
+}
+
+export function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${measurementId}');
+        `}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
- Created GoogleAnalytics component with GA4 integration
- Hardcoded Measurement ID: 
- Stream: privacyhub.in 
- Uses Next.js Script component with afterInteractive strategy
- Added to root layout for site-wide tracking