### PR TITLE
disable: Temporarily disable Turnstile validation

### DIFF
--- a/src/components/PrivacyAnalyzer.tsx
+++ b/src/components/PrivacyAnalyzer.tsx
@@ -183,11 +183,12 @@ export default function PrivacyAnalyzer() {
       return;
     }
 
+    // TURNSTILE DISABLED - Keep code for future use
     // Only require Turnstile token if site key is configured AND bypass is not enabled
-    if (TURNSTILE_SITE_KEY && !turnstileToken && !turnstileBypass) {
-      setError('Please complete the security verification');
-      return;
-    }
+    // if (TURNSTILE_SITE_KEY && !turnstileToken && !turnstileBypass) {
+    //   setError('Please complete the security verification');
+    //   return;
+    // }
 
     setLoading(true);
     setError('');


### PR DESCRIPTION
Disable Turnstile bot protection validation to unblock user flow while keeping all implementation code intact for future debugging. Widget rendering and all server-side verification logic remains in place.