### PR TITLE
fix: Completely disable Turnstile bot protection validation

### DIFF
--- a/TURNSTILE_ISSUE.md
+++ b/TURNSTILE_ISSUE.md
@@ -1,0 +1,105 @@
+# Fix Cloudflare Turnstile widget not loading on Vercel production
+
+## Problem
+
+The Cloudflare Turnstile bot protection widget is not loading on Vercel production deployment. The widget shows "Security verification bypassed - widget failed to load" message instead of rendering properly.
+
+**Current Status:** Turnstile validation has been temporarily disabled (commit 7dfe511) to unblock user flow, but all implementation code remains intact for future fixes.
+
+## Environment
+
+- **Platform:** Vercel (Production)
+- **Mode:** Non-interactive Turnstile
+- **Environment Variables:** ✅ Properly configured in Vercel dashboard
+  - `TURNSTILE_SECRET_KEY` (All Environments)
+  - `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (All Environments)
+
+## What's Already Implemented
+
+### Frontend (`src/components/PrivacyAnalyzer.tsx`)
+- ✅ Native Cloudflare Turnstile JavaScript API integration
+- ✅ Explicit widget rendering with `window.turnstile.render()`
+- ✅ Proper callbacks (success, error, expired, timeout)
+- ✅ Non-interactive mode configuration (`appearance: 'interaction-only'`)
+- ✅ Runtime environment variable loading via `useEffect`
+- ✅ Widget lifecycle management (render, reset, cleanup)
+
+### Backend (`src/app/api/analyze/route.ts`)
+- ✅ Server-side token verification against Cloudflare API
+- ✅ Hostname validation
+- ✅ Proper error handling with specific error messages
+- ✅ Fraud detection with `remoteip` parameter
+
+### Script Loading (`src/app/layout.tsx`)
+- ✅ Turnstile script loaded: `https://challenges.cloudflare.com/turnstile/v0/api.js`
+
+## Issue Details
+
+Despite correct implementation according to official Cloudflare documentation, the widget fails to load on Vercel production. Local environment was not tested.
+
+### Attempted Fixes
+1. ✅ Replaced third-party React wrapper with native API
+2. ✅ Fixed environment variable loading (build-time → runtime)
+3. ✅ Fixed infinite re-render issues in useEffect
+4. ✅ Configured non-interactive mode
+5. ✅ Enhanced server-side validation
+6. ✅ Added comprehensive error handling and logging
+
+### Disabled Code
+The validation check is currently commented out (lines 186-191 in `PrivacyAnalyzer.tsx`):
+```typescript
+// TURNSTILE DISABLED - Keep code for future use
+// if (TURNSTILE_SITE_KEY && !turnstileToken && !turnstileBypass) {
+//   setError('Please complete the security verification');
+//   return;
+// }
+```
+
+## Potential Root Causes to Investigate
+
+1. **Vercel-specific configuration issues**
+   - Content Security Policy blocking Cloudflare script
+   - Next.js build/runtime configuration conflicts
+   - Environment variable propagation timing
+
+2. **Network/CDN issues**
+   - Turnstile script not loading from Cloudflare CDN
+   - CORS or network policy blocking requests
+
+3. **Widget initialization timing**
+   - Script loading race conditions
+   - React hydration conflicts
+
+## Expected Behavior
+
+The Turnstile widget should:
+1. Load and render automatically in non-interactive mode
+2. Show a loading bar while challenge runs
+3. Generate a token upon successful completion
+4. Allow form submission with valid token
+
+## Acceptance Criteria
+
+- [ ] Turnstile widget renders correctly on Vercel production
+- [ ] Widget completes verification in non-interactive mode
+- [ ] Token is generated and validated server-side
+- [ ] Form submission works with valid token
+- [ ] Error states handled gracefully
+- [ ] Uncomment validation check in `PrivacyAnalyzer.tsx` (lines 186-191)
+
+## Documentation References
+
+- [Cloudflare Turnstile Client-Side Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/)
+- [Cloudflare Turnstile Server-Side Validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+
+## Files to Review
+
+- `src/components/PrivacyAnalyzer.tsx` - Frontend widget integration
+- `src/app/api/analyze/route.ts` - Backend verification (lines 310-361)
+- `src/app/layout.tsx` - Script loading (line 108)
+- `.env.example` - Environment variable documentation
+
+---
+
+**Suggested Labels:** `bug`, `production`, `security`, `help-wanted`
+**Priority:** Medium (validation disabled as workaround)

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -289,85 +289,87 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'URL is required' }, { status: 400 });
     }
 
+    // TURNSTILE DISABLED - Keep code for future use
     // Verify Turnstile token (only if secret key is configured)
-    const turnstileSecretKey = process.env.TURNSTILE_SECRET_KEY;
-    if (turnstileSecretKey) {
-      if (!turnstileToken) {
-        console.error('[Turnstile] No token provided in request');
-        return NextResponse.json({
-          error: 'Security verification required. Please complete the security check.'
-        }, { status: 400 });
-      }
+    // const turnstileSecretKey = process.env.TURNSTILE_SECRET_KEY;
+    // if (turnstileSecretKey) {
+    //   if (!turnstileToken) {
+    //     console.error('[Turnstile] No token provided in request');
+    //     return NextResponse.json({
+    //       error: 'Security verification required. Please complete the security check.'
+    //     }, { status: 400 });
+    //   }
 
-      try {
-        console.log('[Turnstile] Validating token with Cloudflare...');
+    //   try {
+    //     console.log('[Turnstile] Validating token with Cloudflare...');
 
-        // Get client IP for enhanced fraud detection
-        const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-                        request.headers.get('x-real-ip') ||
-                        'unknown';
+    //     // Get client IP for enhanced fraud detection
+    //     const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    //                     request.headers.get('x-real-ip') ||
+    //                     'unknown';
 
-        const turnstileResponse = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            secret: turnstileSecretKey,
-            response: turnstileToken,
-            remoteip: clientIp, // Optional but recommended for fraud detection
-          }),
-        });
+    //     const turnstileResponse = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    //       method: 'POST',
+    //       headers: {
+    //         'Content-Type': 'application/json',
+    //       },
+    //       body: JSON.stringify({
+    //         secret: turnstileSecretKey,
+    //         response: turnstileToken,
+    //         remoteip: clientIp, // Optional but recommended for fraud detection
+    //       }),
+    //     });
 
-        const turnstileResult = await turnstileResponse.json() as {
-          success: boolean;
-          'error-codes'?: string[];
-          challenge_ts?: string;
-          hostname?: string;
-          action?: string;
-          cdata?: string;
-        };
+    //     const turnstileResult = await turnstileResponse.json() as {
+    //       success: boolean;
+    //       'error-codes'?: string[];
+    //       challenge_ts?: string;
+    //       hostname?: string;
+    //       action?: string;
+    //       cdata?: string;
+    //     };
 
-        if (!turnstileResult.success) {
-          const errorCodes = turnstileResult['error-codes'] || [];
-          console.error('[Turnstile] Verification failed:', errorCodes);
+    //     if (!turnstileResult.success) {
+    //       const errorCodes = turnstileResult['error-codes'] || [];
+    //       console.error('[Turnstile] Verification failed:', errorCodes);
 
-          // Provide specific error messages based on error codes
-          let errorMessage = 'Security verification failed. Please try again.';
-          if (errorCodes.includes('timeout-or-duplicate')) {
-            errorMessage = 'Security token has expired or was already used. Please refresh and try again.';
-          } else if (errorCodes.includes('invalid-input-response')) {
-            errorMessage = 'Invalid security token. Please refresh the page and try again.';
-          } else if (errorCodes.includes('internal-error')) {
-            errorMessage = 'Security service temporarily unavailable. Please try again.';
-          }
+    //       // Provide specific error messages based on error codes
+    //       let errorMessage = 'Security verification failed. Please try again.';
+    //       if (errorCodes.includes('timeout-or-duplicate')) {
+    //         errorMessage = 'Security token has expired or was already used. Please refresh and try again.';
+    //       } else if (errorCodes.includes('invalid-input-response')) {
+    //         errorMessage = 'Invalid security token. Please refresh the page and try again.';
+    //       } else if (errorCodes.includes('internal-error')) {
+    //         errorMessage = 'Security service temporarily unavailable. Please try again.';
+    //       }
 
-          return NextResponse.json({ error: errorMessage }, { status: 403 });
-        }
+    //       return NextResponse.json({ error: errorMessage }, { status: 403 });
+    //     }
 
-        // Validate hostname matches your domain (security best practice)
-        const expectedHostnames = ['privacyhub.in', 'www.privacyhub.in', 'localhost'];
-        if (turnstileResult.hostname && !expectedHostnames.includes(turnstileResult.hostname)) {
-          console.error('[Turnstile] Hostname mismatch:', turnstileResult.hostname);
-          return NextResponse.json({
-            error: 'Security verification failed: invalid origin.'
-          }, { status: 403 });
-        }
+    //     // Validate hostname matches your domain (security best practice)
+    //     const expectedHostnames = ['privacyhub.in', 'www.privacyhub.in', 'localhost'];
+    //     if (turnstileResult.hostname && !expectedHostnames.includes(turnstileResult.hostname)) {
+    //       console.error('[Turnstile] Hostname mismatch:', turnstileResult.hostname);
+    //       return NextResponse.json({
+    //         error: 'Security verification failed: invalid origin.'
+    //       }, { status: 403 });
+    //     }
 
-        console.log('[Turnstile] Verification successful', {
-          hostname: turnstileResult.hostname,
-          challenge_ts: turnstileResult.challenge_ts,
-          clientIp: clientIp.substring(0, 10) + '...' // Log partial IP for privacy
-        });
-      } catch (turnstileError) {
-        console.error('[Turnstile] Verification error:', turnstileError);
-        return NextResponse.json({
-          error: 'Security verification error. Please try again.'
-        }, { status: 500 });
-      }
-    } else {
-      console.warn('[Turnstile] TURNSTILE_SECRET_KEY not configured - skipping verification (development mode)');
-    }
+    //     console.log('[Turnstile] Verification successful', {
+    //       hostname: turnstileResult.hostname,
+    //       challenge_ts: turnstileResult.challenge_ts,
+    //       clientIp: clientIp.substring(0, 10) + '...' // Log partial IP for privacy
+    //     });
+    //   } catch (turnstileError) {
+    //     console.error('[Turnstile] Verification error:', turnstileError);
+    //     return NextResponse.json({
+    //       error: 'Security verification error. Please try again.'
+    //     }, { status: 500 });
+    //   }
+    // } else {
+    //   console.warn('[Turnstile] TURNSTILE_SECRET_KEY not configured - skipping verification (development mode)');
+    // }
+    console.log('[Turnstile] Validation disabled - skipping verification');
 
     // Validate and sanitize URL
     const urlValidation = validateUrl(url);

--- a/src/components/PrivacyAnalyzer.tsx
+++ b/src/components/PrivacyAnalyzer.tsx
@@ -129,17 +129,20 @@ export default function PrivacyAnalyzer() {
             },
             'error-callback': (errorCode?: string) => {
               console.error('[Turnstile] Error:', errorCode);
-              setError('Security verification failed. Please refresh and try again.');
+              // TURNSTILE DISABLED - Don't set error messages
+              // setError('Security verification failed. Please refresh and try again.');
               setTurnstileToken('');
             },
             'expired-callback': () => {
               console.log('[Turnstile] Token expired');
               setTurnstileToken('');
-              setError('Security verification expired. Please verify again.');
+              // TURNSTILE DISABLED - Don't set error messages
+              // setError('Security verification expired. Please verify again.');
             },
             'timeout-callback': () => {
               console.log('[Turnstile] Timeout');
-              setError('Security verification timed out. Please try again.');
+              // TURNSTILE DISABLED - Don't set error messages
+              // setError('Security verification timed out. Please try again.');
               setTurnstileToken('');
             },
           });
@@ -311,18 +314,19 @@ export default function PrivacyAnalyzer() {
               />
             </div>
 
-            {/* Turnstile Security Verification */}
-            {TURNSTILE_SITE_KEY && !turnstileBypass && (
+            {/* Turnstile Security Verification - DISABLED */}
+            {/* TURNSTILE DISABLED - Keep code for future use */}
+            {/* {TURNSTILE_SITE_KEY && !turnstileBypass && (
               <div className="flex justify-center">
                 <div ref={turnstileContainerRef} className="turnstile-widget" />
               </div>
-            )}
+            )} */}
 
             {/* Action Buttons */}
             <div className="flex flex-col sm:flex-row gap-3 pt-2">
               <Button
                 onClick={analyzePolicy}
-                disabled={loading || !url.trim() || (!!TURNSTILE_SITE_KEY && !turnstileToken && !turnstileBypass)}
+                disabled={loading || !url.trim()}
                 className="flex-1 h-12 text-base font-bold bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 hover:from-blue-700 hover:via-purple-700 hover:to-pink-700 text-white border-0 shadow-lg hover:shadow-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? (


### PR DESCRIPTION
Disable all Turnstile validation checks (frontend and backend) to unblock user flow. All implementation code preserved for future debugging and re-enabling.

Changes:
- Hide Turnstile widget from UI
- Remove button disable condition based on token
- Disable error message callbacks
- Comment out server-side token verification
- Form now works without security check