### PR TITLE
fix: Update cron schedule to daily 

### DIFF
--- a/src/app/api/cron/refresh-keys/route.ts
+++ b/src/app/api/cron/refresh-keys/route.ts
@@ -5,14 +5,14 @@ export const dynamic = 'force-dynamic';
 
 /**
  * Cron endpoint to refresh OpenRouter API key statuses
- * Runs every 12 hours to check credits and rate limits
+ * Runs daily to check credits and rate limits
  *
  * To enable on Vercel:
  * Add to vercel.json:
  * {
  *   "crons": [{
  *     "path": "/api/cron/refresh-keys",
- *     "schedule": "0 STAR/12 * * *"  (replace STAR with *)
+ *     "schedule": "0 0 * * *"  (daily at midnight UTC)
  *   }]
  * }
  */

--- a/src/lib/openrouter-key-manager.ts
+++ b/src/lib/openrouter-key-manager.ts
@@ -19,7 +19,7 @@ interface KeyUsageCache {
 
 // In-memory cache for key status (resets on serverless function restart)
 const keyStatusCache: KeyUsageCache = {};
-const CACHE_DURATION = 12 * 60 * 60 * 1000; // 12 hours in milliseconds
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 
 /**
  * Get all available API keys from environment

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "crons": [
     {
       "path": "/api/cron/refresh-keys",
-      "schedule": "0 */12 * * *"
+      "schedule": "0 0 * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
Fixes deployment issues caused by cron schedule i

## Changes
- Update cron schedule from every 12 hours to daily (0 0 * * *)
- Update cache duration from 12 hours to 24 hours


## Key Rotation Still Works
- Daily proactive checks for key health
- Immediate failover on rate limit errors (real-time)
- 24-hour cache prevents unnecessary API calls