### PR TITLE
Audience sections: user rights action plan + DPDP compliance scorecard

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -292,9 +292,48 @@ Provide your response in this JSON format:
     "medium_term_improvements": ["privacy enhancements for Indian users"],
     "best_practice_adoption": ["industry leading practices to consider for Indian market"]
   },
+  "user_action_plan": {
+    "summary": "1-2 plain-language sentences telling a regular, non-technical Indian user what this policy means for THEIR personal data and privacy — no jargon",
+    "top_actions": [
+      {"action": "concrete, specific step this user should take (e.g. 'Turn off ad personalization in Settings > Privacy')", "why": "plain-language reason it matters to them", "priority": "HIGH/MEDIUM/LOW"}
+    ],
+    "your_rights": [
+      {"right": "Right to Access", "dpdp_reference": "Sec 11", "available": "YES/PARTIAL/UNCLEAR/NO", "how_to_use": "how THIS user can exercise it with this specific service based on the policy (mention the contact/grievance channel if stated)"},
+      {"right": "Right to Correction & Erasure", "dpdp_reference": "Sec 12", "available": "YES/PARTIAL/UNCLEAR/NO", "how_to_use": "..."},
+      {"right": "Right to Grievance Redressal", "dpdp_reference": "Sec 13", "available": "YES/PARTIAL/UNCLEAR/NO", "how_to_use": "..."},
+      {"right": "Right to Nominate", "dpdp_reference": "Sec 14", "available": "YES/PARTIAL/UNCLEAR/NO", "how_to_use": "..."},
+      {"right": "Right to Withdraw Consent", "dpdp_reference": "Sec 6/7", "available": "YES/PARTIAL/UNCLEAR/NO", "how_to_use": "..."}
+    ],
+    "watch_outs": ["specific things IN THIS policy the user should be cautious about, in plain language (max 4)"]
+  },
+  "compliance_scorecard": {
+    "overall_health": "1-2 sentence verdict on the organisation's PII-handling health under DPDP for a compliance/legal owner",
+    "pii_handling_health_score": number (1-10, how healthy their overall data handling is vs DPDP Act 2023 + Rules 2025),
+    "obligations": [
+      {"area": "Notice", "dpdp_reference": "Sec 5, Rule 3", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "what the policy does/omits", "action_required": "specific fix to close the gap"},
+      {"area": "Consent (free, specific, informed, withdrawable)", "dpdp_reference": "Sec 6", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Data Principal Rights", "dpdp_reference": "Sec 11-14, Rule 14", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Security Safeguards", "dpdp_reference": "Sec 8(5), Rule 6", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Breach Notification (Board within 72h)", "dpdp_reference": "Sec 8(6), Rule 7", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Retention & Erasure", "dpdp_reference": "Sec 8(7), Rule 8, Third Schedule", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Children's Data (verifiable parental consent, no targeting <18)", "dpdp_reference": "Sec 9, Rule 10", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED/NOT_APPLICABLE", "finding": "...", "action_required": "..."},
+      {"area": "Grievance Officer / Contact", "dpdp_reference": "Sec 8(10)", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."},
+      {"area": "Cross-Border Transfers", "dpdp_reference": "Sec 16, Rule 15", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED/NOT_APPLICABLE", "finding": "...", "action_required": "..."},
+      {"area": "Significant Data Fiduciary (DPO, DPIA, audit)", "dpdp_reference": "Sec 10, Rule 13", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED/NOT_APPLICABLE", "finding": "...", "action_required": "..."},
+      {"area": "Processor Contracts", "dpdp_reference": "Sec 8(2)", "status": "MET/PARTIAL/GAP/NOT_ADDRESSED", "finding": "...", "action_required": "..."}
+    ],
+    "priority_gaps": ["the most urgent gaps to fix first, ordered by importance (max 5)"]
+  },
   "privacy_grade": "string (A+ to F based on risk level)",
   "executive_summary": "Professional 2-3 sentence assessment for Indian stakeholders focusing on DPDP Act 2023 and Rules 2025 compliance"
 }
+
+IMPORTANT DPDP GROUNDING (be accurate — DPDP Rules 2025 were notified 13 Nov 2025):
+- Data Principal rights: Access (Sec 11), Correction & Erasure (Sec 12), Grievance Redressal (Sec 13), Nominate (Sec 14), Withdraw Consent (Sec 6/7). Exercising rights is free unless excessive/repetitive. A "child" is anyone under 18.
+- Breach notification: notify affected Data Principals without delay AND report to the Data Protection Board within 72 hours (Rule 7); non-compliance penalty up to Rs 200 crore.
+- Retention (Rule 8, Third Schedule): erase when purpose served or consent withdrawn; large e-commerce (2 cr+ users), online gaming (50 lakh+), and social-media (2 cr+) fiduciaries must erase 3 years after last user interaction; 1-year minimum log retention.
+- Only Significant Data Fiduciaries (designated by Government) must appoint a DPO (India-based), run DPIAs, and get audited.
+For 'user_action_plan' write for a non-technical common person and prioritise THEIR privacy and rights. For 'compliance_scorecard' write for the policy owner/compliance team with specific, actionable DPDP gaps. Base every finding ONLY on evidence in the provided policy; if the policy is silent on an obligation, mark it GAP or NOT_ADDRESSED (not MET).
 `;
 
 export async function POST(request: NextRequest) {
@@ -700,7 +739,7 @@ export async function POST(request: NextRequest) {
 
         console.log(`[Analysis] Using ${keyName} for AI analysis (attempt ${attempt + 1}/${maxRetries})`);
         console.log(`[OpenRouter] Sending request to model: ${currentModel}`);
-        console.log(`[OpenRouter] Request params: temperature=0.3, maxTokens=4000, content_length=${content.length}`);
+        console.log(`[OpenRouter] Request params: temperature=0.3, maxTokens=6000, content_length=${content.length}`);
 
         const completion = await openrouter.chat.send({
           chatGenerationParams: {
@@ -716,7 +755,7 @@ export async function POST(request: NextRequest) {
               }
             ],
             temperature: 0.3,
-            maxTokens: 4000,
+            maxTokens: 6000,
             stream: false,
           },
         }).catch((apiError: any) => {

--- a/src/app/results/[domain]/page.tsx
+++ b/src/app/results/[domain]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { UserActionPlan, ComplianceScorecard } from '@/components/AudienceSections';
 
 // Helper function to get grade color
 function getGradeColor(grade: string): string {
@@ -221,6 +222,20 @@ export default function ResultsPage() {
             <p className="text-slate-700 leading-relaxed">{analysisData.executive_summary}</p>
           </CardContent>
         </Card>
+
+        {/* For You — user rights & action plan (priority audience) */}
+        {analysisData.user_action_plan && (
+          <div className="mb-8">
+            <UserActionPlan plan={analysisData.user_action_plan} />
+          </div>
+        )}
+
+        {/* For Policy Owners — DPDP compliance scorecard */}
+        {analysisData.compliance_scorecard && (
+          <div className="mb-8">
+            <ComplianceScorecard card={analysisData.compliance_scorecard} />
+          </div>
+        )}
 
         {/* Category Scores */}
         <Card className="mb-8">

--- a/src/components/AudienceSections.tsx
+++ b/src/components/AudienceSections.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React from 'react';
+import { AlertCircle, CheckCircle, XCircle, MinusCircle, ArrowRight, UserCheck, Building2, ShieldCheck } from 'lucide-react';
+
+export interface UserActionPlanData {
+  summary?: string;
+  top_actions?: { action: string; why?: string; priority?: string }[];
+  your_rights?: { right: string; dpdp_reference?: string; available?: string; how_to_use?: string }[];
+  watch_outs?: string[];
+}
+
+export interface ComplianceScorecardData {
+  overall_health?: string;
+  pii_handling_health_score?: number;
+  obligations?: { area: string; dpdp_reference?: string; status?: string; finding?: string; action_required?: string }[];
+  priority_gaps?: string[];
+}
+
+function priorityStyle(p?: string) {
+  const v = (p || '').toUpperCase();
+  if (v === 'HIGH') return 'bg-rose-50 text-rose-700 ring-rose-200';
+  if (v === 'MEDIUM') return 'bg-amber-50 text-amber-700 ring-amber-200';
+  return 'bg-slate-100 text-slate-600 ring-slate-200';
+}
+
+function rightAvailability(a?: string) {
+  const v = (a || '').toUpperCase();
+  if (v === 'YES') return { icon: <CheckCircle className="h-4 w-4 text-emerald-600" />, label: 'Available' };
+  if (v === 'PARTIAL') return { icon: <AlertCircle className="h-4 w-4 text-amber-600" />, label: 'Partial' };
+  if (v === 'NO') return { icon: <XCircle className="h-4 w-4 text-rose-600" />, label: 'Not offered' };
+  return { icon: <MinusCircle className="h-4 w-4 text-slate-400" />, label: 'Unclear' };
+}
+
+export function UserActionPlan({ plan }: { plan: UserActionPlanData }) {
+  const actions = plan.top_actions?.filter((a) => a?.action) || [];
+  const rights = plan.your_rights?.filter((r) => r?.right) || [];
+  const watchOuts = plan.watch_outs?.filter(Boolean) || [];
+  return (
+    <div className="rounded-2xl border border-indigo-100 bg-gradient-to-br from-indigo-50/60 to-white p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white">
+          <UserCheck className="h-3.5 w-3.5" /> For You
+        </span>
+        <h3 className="text-base font-bold text-slate-900">Your privacy — what to do</h3>
+      </div>
+      {plan.summary && <p className="mb-5 text-sm leading-relaxed text-slate-600">{plan.summary}</p>}
+
+      {actions.length > 0 && (
+        <div className="mb-6">
+          <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Recommended actions</h4>
+          <ul className="space-y-2.5">
+            {actions.map((a, i) => (
+              <li key={i} className="flex items-start gap-3 rounded-xl border border-slate-100 bg-white p-3">
+                <span className={`mt-0.5 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ring-1 ${priorityStyle(a.priority)}`}>{a.priority || 'TIP'}</span>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-slate-800">{a.action}</p>
+                  {a.why && <p className="mt-0.5 text-xs text-slate-500">{a.why}</p>}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {rights.length > 0 && (
+        <div className="mb-6">
+          <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Your rights under India&apos;s DPDP Act</h4>
+          <div className="grid gap-2.5 sm:grid-cols-2">
+            {rights.map((r, i) => {
+              const av = rightAvailability(r.available);
+              return (
+                <div key={i} className="rounded-xl border border-slate-100 bg-white p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-1.5 text-sm font-semibold text-slate-800">{av.icon}{r.right}</span>
+                    {r.dpdp_reference && <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">{r.dpdp_reference}</span>}
+                  </div>
+                  {r.how_to_use && <p className="mt-1.5 text-xs leading-relaxed text-slate-500">{r.how_to_use}</p>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {watchOuts.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">Watch out for</h4>
+          <ul className="space-y-1.5">
+            {watchOuts.map((w, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-slate-600">
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />{w}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function statusStyle(s?: string) {
+  const v = (s || '').toUpperCase();
+  if (v === 'MET') return { cls: 'bg-emerald-50 text-emerald-700 ring-emerald-200', label: 'Met' };
+  if (v === 'PARTIAL') return { cls: 'bg-amber-50 text-amber-700 ring-amber-200', label: 'Partial' };
+  if (v === 'GAP') return { cls: 'bg-rose-50 text-rose-700 ring-rose-200', label: 'Gap' };
+  if (v === 'NOT_APPLICABLE') return { cls: 'bg-slate-100 text-slate-500 ring-slate-200', label: 'N/A' };
+  return { cls: 'bg-slate-100 text-slate-600 ring-slate-200', label: 'Not addressed' };
+}
+
+export function ComplianceScorecard({ card }: { card: ComplianceScorecardData }) {
+  const obligations = card.obligations?.filter((o) => o?.area) || [];
+  const gaps = card.priority_gaps?.filter(Boolean) || [];
+  const health = typeof card.pii_handling_health_score === 'number' ? card.pii_handling_health_score : null;
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white">
+          <Building2 className="h-3.5 w-3.5" /> For Policy Owners
+        </span>
+        <h3 className="text-base font-bold text-slate-900">DPDP compliance health</h3>
+        {health !== null && (
+          <span className="ml-auto flex items-center gap-1.5 text-sm">
+            <ShieldCheck className="h-4 w-4 text-slate-400" />
+            <span className="font-bold text-slate-900">{health.toFixed(1)}</span>
+            <span className="text-slate-400">/10 handling health</span>
+          </span>
+        )}
+      </div>
+      {card.overall_health && <p className="mb-5 text-sm leading-relaxed text-slate-600">{card.overall_health}</p>}
+
+      {obligations.length > 0 && (
+        <div className="mb-6 overflow-hidden rounded-xl border border-slate-100">
+          {obligations.map((o, i) => {
+            const st = statusStyle(o.status);
+            const upper = (o.status || '').toUpperCase();
+            return (
+              <div key={i} className={`p-4 ${i > 0 ? 'border-t border-slate-100' : ''}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-800">{o.area}</p>
+                    {o.dpdp_reference && <p className="text-[11px] text-slate-400">{o.dpdp_reference}</p>}
+                  </div>
+                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase ring-1 ${st.cls}`}>{st.label}</span>
+                </div>
+                {o.finding && <p className="mt-2 text-xs text-slate-500">{o.finding}</p>}
+                {o.action_required && upper !== 'MET' && upper !== 'NOT_APPLICABLE' && (
+                  <p className="mt-1.5 flex items-start gap-1.5 text-xs font-medium text-slate-700">
+                    <ArrowRight className="mt-0.5 h-3 w-3 shrink-0 text-slate-400" />{o.action_required}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {gaps.length > 0 && (
+        <div className="rounded-xl border border-rose-100 bg-rose-50/50 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-rose-700">Fix these first</h4>
+          <ol className="space-y-1.5">
+            {gaps.map((g, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-slate-700">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-rose-600 text-[10px] font-bold text-white">{i + 1}</span>{g}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PrivacyAnalyzer.tsx
+++ b/src/components/PrivacyAnalyzer.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { AlertCircle, CheckCircle, Search, ExternalLink, Shield, Lock, Eye, Users, FileText, Scale, RotateCcw } from 'lucide-react';
+import { UserActionPlan, ComplianceScorecard } from '@/components/AudienceSections';
 import {
   Chart as ChartJS,
   RadialLinearScale,
@@ -63,6 +64,19 @@ interface AnalysisResult {
     };
     privacy_grade: string;
     executive_summary: string;
+    dpdp_compliance_score?: number;
+    user_action_plan?: {
+      summary?: string;
+      top_actions?: { action: string; why?: string; priority?: string }[];
+      your_rights?: { right: string; dpdp_reference?: string; available?: string; how_to_use?: string }[];
+      watch_outs?: string[];
+    };
+    compliance_scorecard?: {
+      overall_health?: string;
+      pii_handling_health_score?: number;
+      obligations?: { area: string; dpdp_reference?: string; status?: string; finding?: string; action_required?: string }[];
+      priority_gaps?: string[];
+    };
   };
 }
 
@@ -527,6 +541,11 @@ export default function PrivacyAnalyzer() {
             <p className="text-sm text-gray-600 leading-relaxed">{result.analysis.executive_summary}</p>
           </div>
 
+          {/* For You — user rights & action plan (priority audience) */}
+          {result.analysis.user_action_plan && (
+            <UserActionPlan plan={result.analysis.user_action_plan} />
+          )}
+
           {/* Charts Row: Radar + Bar */}
           <div className="grid sm:grid-cols-2 gap-6">
             <div>
@@ -566,6 +585,11 @@ export default function PrivacyAnalyzer() {
               })}
             </div>
           </div>
+
+          {/* For Policy Owners — DPDP compliance scorecard */}
+          {result.analysis.compliance_scorecard && (
+            <ComplianceScorecard card={result.analysis.compliance_scorecard} />
+          )}
 
           {/* Critical Findings with Donut */}
           {allFindings.length > 0 && (


### PR DESCRIPTION
Adds two audience-focused sections to results, grounded in DPDP Act 2023 + Rules 2025 (notified 13 Nov 2025):

**For You (end users):** plain-language action plan, their DPDP rights (§11–14, §6/7) with how to exercise each on this service, and watch-outs.

**For Policy Owners:** PII-handling health score + DPDP obligation scorecard (Notice, Consent, Rights, Security, 72h breach, Retention/Third Schedule, Children, Grievance, Cross-border, SDF, Processor contracts) with MET/PARTIAL/GAP status and specific fixes.

Prompt extended with verified DPDP grounding; maxTokens 4000→6000; shared component rendered in analyzer + stored report views. Typecheck + build clean.