### PR TITLE
Anchor scoring rubric (consistent, evidence-based, defensible)

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -183,7 +183,22 @@ DUAL SCORING METHODOLOGY:
      * Grievance redressal (Sec. 13 right; Sec. 8(10) fiduciary obligation)
      * DPO appointment where required (Rule 13)
 
-CATEGORY SCORING: Rate each category 1-10 (10 = exemplary privacy protection, 1 = significant privacy risk)
+CATEGORY SCORING: Rate each category 1-10 using the anchored rubric below.
+
+SCORING RUBRIC (apply the same anchored scale to every category so scores are consistent and defensible):
+- 9-10 (Exemplary): The policy EXPLICITLY provides privacy-by-design protections that meet AND exceed the DPDP obligations for this category, with specific, verifiable mechanisms (named tools, contacts, timelines, safeguards).
+- 7-8 (Strong): The policy explicitly meets the core DPDP obligations for this category with clear, specific commitments; only minor gaps.
+- 5-6 (Adequate): Basic protections are present but vague, partial, or with notable gaps; several obligations are only implied rather than stated.
+- 3-4 (Weak): Minimal protection; the policy is largely silent on, or contradicts, key DPDP obligations; user-unfavourable defaults.
+- 1-2 (Poor): No meaningful protection; likely DPDP non-compliance; the policy permits broad collection/sharing with little user control.
+
+MANDATORY EVIDENCE RULES (these keep scoring objective and reproducible):
+1. Score ONLY on what the policy text EXPLICITLY states. Do not assume, infer good faith, or credit practices the policy does not describe.
+2. Silence = not met. If the policy does not address an obligation, treat that obligation as ABSENT and score it low — do not give benefit of the doubt.
+3. Ground every category score in the criteria listed for that category: the score reflects the PROPORTION of that category's criteria that are explicitly and verifiably satisfied.
+4. In each category's "reasoning", cite specific evidence (quote or paraphrase the relevant policy statement) or explicitly note its absence. Vague reasoning is not acceptable.
+5. Be consistent: the same policy text must map to the same score band every time.
+
 
 **DATA MINIMIZATION & COLLECTION PRACTICES (Weight: 30%)**
 Evaluate against DPDP Act 2023 Sec. 5 and DPDP Rules 2025 privacy-by-design principles:
@@ -739,7 +754,7 @@ export async function POST(request: NextRequest) {
 
         console.log(`[Analysis] Using ${keyName} for AI analysis (attempt ${attempt + 1}/${maxRetries})`);
         console.log(`[OpenRouter] Sending request to model: ${currentModel}`);
-        console.log(`[OpenRouter] Request params: temperature=0.3, maxTokens=6000, content_length=${content.length}`);
+        console.log(`[OpenRouter] Request params: temperature=0.1, maxTokens=6000, content_length=${content.length}`);
 
         const completion = await openrouter.chat.send({
           chatGenerationParams: {
@@ -754,7 +769,7 @@ export async function POST(request: NextRequest) {
                 content: `Analyze this privacy policy:\n\n${smartTruncate(content, 16000)}`
               }
             ],
-            temperature: 0.3,
+            temperature: 0.1, // low temperature for consistent, reproducible scoring
             maxTokens: 6000,
             stream: false,
           },

--- a/src/components/MethodologySection.tsx
+++ b/src/components/MethodologySection.tsx
@@ -408,6 +408,46 @@ export function MethodologySection() {
               </div>
             </div>
 
+            {/* Scoring Rubric */}
+            <div>
+              <h5 className="text-lg font-semibold text-blue-900 mb-4 flex items-center gap-2">
+                <Calculator className="h-5 w-5" />
+                How Each Category Is Scored (1–10 Rubric)
+              </h5>
+              <p className="text-sm text-blue-800 mb-4">
+                Every category uses the same anchored scale, so a given policy maps to the same band consistently.
+                Scores reflect <strong>only what the policy explicitly states</strong> — if an obligation is not
+                addressed, it is treated as absent and scored low (no benefit of the doubt).
+              </p>
+              <div className="space-y-2 mb-4">
+                {[
+                  { band: '9–10', label: 'Exemplary', desc: 'Explicit privacy-by-design protections that meet and exceed DPDP obligations, with specific verifiable mechanisms.', color: 'bg-green-100 text-green-800 border-green-300' },
+                  { band: '7–8', label: 'Strong', desc: 'Explicitly meets the core DPDP obligations with clear, specific commitments; only minor gaps.', color: 'bg-blue-100 text-blue-800 border-blue-300' },
+                  { band: '5–6', label: 'Adequate', desc: 'Basic protections present but vague, partial, or with notable gaps; several obligations only implied.', color: 'bg-yellow-100 text-yellow-800 border-yellow-300' },
+                  { band: '3–4', label: 'Weak', desc: 'Minimal protection; largely silent on or contradicting key DPDP obligations; user-unfavourable defaults.', color: 'bg-orange-100 text-orange-800 border-orange-300' },
+                  { band: '1–2', label: 'Poor', desc: 'No meaningful protection; likely DPDP non-compliance; broad collection/sharing with little user control.', color: 'bg-red-100 text-red-800 border-red-300' },
+                ].map((r, i) => (
+                  <div key={i} className="flex items-start gap-3 bg-white rounded-lg p-3 border-2 border-blue-100">
+                    <Badge className={`${r.color} font-bold text-sm px-3 py-1 border shrink-0`}>{r.band}</Badge>
+                    <div>
+                      <span className="text-sm font-semibold text-blue-900">{r.label}</span>
+                      <p className="text-xs text-blue-700 mt-0.5">{r.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="bg-white rounded-lg p-4 border-2 border-indigo-200">
+                <p className="text-sm font-semibold text-indigo-900 mb-1">Overall score formula</p>
+                <p className="text-xs text-indigo-800">
+                  A category&apos;s score = the proportion of its listed criteria that are explicitly satisfied.
+                  The overall score is the fixed weighted average
+                  <strong> Σ(category × weight)</strong> (weights: 30 / 25 / 20 / 15 / 7 / 3 = 100%). The grade
+                  (A+ to F) and risk level are then derived by fixed numeric thresholds — this final step is fully
+                  deterministic and identical for the same category scores every time.
+                </p>
+              </div>
+            </div>
+
             {/* Risk Classification */}
             <div>
               <h5 className="text-lg font-semibold text-blue-900 mb-4 flex items-center gap-2">


### PR DESCRIPTION
Makes the scoring mechanism scientifically defensible.

- **Anchored 1-10 rubric** applied identically to every category (Exemplary 9-10 … Poor 1-2), each band defined by observable, DPDP-tied criteria — replaces the vague 'rate 1-10' instruction.
- **Mandatory evidence rules:** score only on explicit policy text; silence = obligation absent = low score; category score = proportion of criteria explicitly satisfied; reasoning must cite evidence.
- **Temperature 0.3 → 0.1** for reproducibility.
- **Deterministic aggregation** unchanged: score = Σ(category × weight), fixed grade/risk thresholds.
- The full rubric + formula are now **published on the methodology page** so the mechanism is transparent and auditable.

Typecheck + build clean.